### PR TITLE
Fix username detection for transcription checks

### DIFF
--- a/bubbles/commands/periodic/transcription_check_ping.py
+++ b/bubbles/commands/periodic/transcription_check_ping.py
@@ -11,7 +11,7 @@ import time
 import urllib
 
 
-USERNAME_REGEX = re.compile("u/(?P<username>[^ ]+)")
+USERNAME_REGEX = re.compile("u/(?P<username>[^ *:]+)")
 
 
 def get_username_and_permalink(message):


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This prevents colons and asterisks from being picked up with the username.

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
