### PR TITLE
Fix check reminder aggregation by time

### DIFF
--- a/bubbles/commands/periodic/transcription_check_ping.py
+++ b/bubbles/commands/periodic/transcription_check_ping.py
@@ -215,7 +215,7 @@ def _aggregate_checks_by_time(checks: List[CheckData]) -> List:
     """Aggregate the given checks by the elapsed time."""
     now = datetime.now()
     # Sort the checks by their time
-    checks.sort(key=lambda x: x["time"])
+    checks.sort(key=lambda x: x["time"], reverse=True)
 
     aggregate = []
 
@@ -244,6 +244,10 @@ def _aggregate_checks_by_time(checks: List[CheckData]) -> List:
             # Further aggregate by moderators
             mod_aggregate = _aggregate_checks_by_mod(time_checks)
             aggregate.append((time_str, mod_aggregate))
+
+    # Add the remaining checks
+    rest_aggregate = _aggregate_checks_by_mod(checks[index:])
+    aggregate.append((CHECK_TIME_FALLBACK, rest_aggregate))
 
     return aggregate
 


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Fixed order that the checks are processed in and add the remaining checks that are >7 days old.

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
