### PR TITLE
Ignore excited messages

### DIFF
--- a/bubbles/commands/exclamation.py
+++ b/bubbles/commands/exclamation.py
@@ -1,0 +1,14 @@
+from bubbles.config import PluginManager
+
+
+def exclamation(payload):
+    """Ignore messages starting with multiple exclamation marks.
+
+    Messages such as "!!! I'm so excited !!!" used to trigger the
+    "Unknown command" response. Instead, we now sinkhole such commands
+    with this function and ignore them entirely.
+    """
+    pass
+
+
+PluginManager.register_plugin(exclamation, r"!")


### PR DESCRIPTION
Relevant issue: #30

## Description:

Messages starting with multiple exclamation marks are now ignored as they are usually not meant to be a command.

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
