### PR TITLE
Fix command recognition

### DIFF
--- a/bubbles/commands/__init__.py
+++ b/bubbles/commands/__init__.py
@@ -8,8 +8,7 @@ from typing import List, Union
 import glob
 from os.path import dirname, basename, isfile, join
 
-from bubbles.config import COMMAND_PREFIXES
-
+from bubbles.config import PluginManager
 
 modules = glob.glob(join(dirname(__file__), "*.py"))
 __all__ = [
@@ -27,8 +26,7 @@ def clean_text(text: Union[str, List]) -> str:
         @bubbles test -> test
         @bubbles test one -> test one
     """
-    if not isinstance(text, list):
-        text = text.split()
-    if text[0] in COMMAND_PREFIXES:
-        text.pop(0)
-    return " ".join(text)
+    if isinstance(text, list):
+        text = " ".join(text)
+
+    return PluginManager.try_get_command_text(text) or text

--- a/bubbles/commands/backup_db.py
+++ b/bubbles/commands/backup_db.py
@@ -41,6 +41,6 @@ def backup_db(payload):
 
 PluginManager.register_plugin(
     backup_db,
-    r"backup",
+    r"^backup",
     help="!backup - creates and uploads a full backup of our postgres db.",
 )

--- a/bubbles/commands/cute.py
+++ b/bubbles/commands/cute.py
@@ -116,7 +116,7 @@ def cute(data):
 
 PluginManager.register_plugin(
     cute,
-    r"cute",
+    r"^cute",
     help=(
         f"!cute [{', '.join([k for k in animals.keys()])}] - Specify an animal"
         f" for a cute picture! Or just !cute for a random one."

--- a/bubbles/commands/deploy.py
+++ b/bubbles/commands/deploy.py
@@ -121,7 +121,7 @@ def deploy(payload):
 
 PluginManager.register_plugin(
     deploy,
-    r"deploy ?(.+)",
+    r"^deploy ?(.+)",
     help=(
         f"!deploy [{', '.join(SERVICES)}] - deploys the code currently on github to"
         f" production."

--- a/bubbles/commands/echo.py
+++ b/bubbles/commands/echo.py
@@ -24,5 +24,5 @@ def echo(payload):
 
 
 PluginManager.register_plugin(
-    echo, r"echo", help="Repeats back whatever you pass in. Mostly for debugging."
+    echo, r"^echo", help="Repeats back whatever you pass in. Mostly for debugging."
 )

--- a/bubbles/commands/exclamation.py
+++ b/bubbles/commands/exclamation.py
@@ -11,4 +11,4 @@ def exclamation(payload):
     pass
 
 
-PluginManager.register_plugin(exclamation, r"!")
+PluginManager.register_plugin(exclamation, r"^!")

--- a/bubbles/commands/help.py
+++ b/bubbles/commands/help.py
@@ -32,5 +32,5 @@ def help(payload):
 
 
 PluginManager.register_plugin(
-    help, r"help$", help="!help - Lists out all available commands!"
+    help, r"^help$", help="!help - Lists out all available commands!"
 )

--- a/bubbles/commands/isup.py
+++ b/bubbles/commands/isup.py
@@ -33,5 +33,5 @@ def isup(payload):
 
 
 PluginManager.register_plugin(
-    isup, r"isup([ a-zA-Z]+)?", help="!isup [service_name]", interactive_friendly=False
+    isup, r"^isup([ a-zA-Z]+)?", help="!isup [service_name]", interactive_friendly=False
 )

--- a/bubbles/commands/logs.py
+++ b/bubbles/commands/logs.py
@@ -34,5 +34,5 @@ def logs(payload):
 
 
 PluginManager.register_plugin(
-    logs, r"logs([ a-zA-Z]+)?", help="!logs [service_name]", interactive_friendly=False
+    logs, r"^logs([ a-zA-Z]+)?", help="!logs [service_name]", interactive_friendly=False
 )

--- a/bubbles/commands/ping.py
+++ b/bubbles/commands/ping.py
@@ -5,4 +5,4 @@ def ping(payload):
     payload["extras"]["say"]("PONG!")
 
 
-PluginManager.register_plugin(ping, r"ping$", help="!ping - PONG")
+PluginManager.register_plugin(ping, r"^ping$", help="!ping - PONG")

--- a/bubbles/commands/plot_comments_history.py
+++ b/bubbles/commands/plot_comments_history.py
@@ -108,7 +108,7 @@ def plot_comments_history(payload: Dict) -> None:
 
 PluginManager.register_plugin(
     plot_comments_history,
-    r"(?!.*who)history([0-9 ]+)?",
+    r"^history([0-9 ]+)?",
     help=(
         "!history [number of posts] - shows the number of new comments in"
         " #new-volunteers in function of their day. `number of posts` must"

--- a/bubbles/commands/plot_comments_historylist.py
+++ b/bubbles/commands/plot_comments_historylist.py
@@ -69,7 +69,7 @@ def plot_comments_historylist(payload: Dict) -> None:
 
 PluginManager.register_plugin(
     plot_comments_historylist,
-    r"(?!.*who)listmodsTEST ([0-9 ]+)?",
+    r"^listmodsTEST ([0-9 ]+)?",
     help=(
         "!historylist [number of posts] - shows the number of new comments in"
         " #new-volunteers in function of the mod having welcomed them. `number"

--- a/bubbles/commands/plot_comments_historywho.py
+++ b/bubbles/commands/plot_comments_historywho.py
@@ -163,5 +163,5 @@ def plot_comments_historywho(payload: Dict) -> None:
 
 
 PluginManager.register_plugin(
-    plot_comments_historywho, r"historywho([ \"a-zA-Z]+)?", help=HELP_MESSAGE,
+    plot_comments_historywho, r"^historywho([ \"a-zA-Z]+)?", help=HELP_MESSAGE,
 )

--- a/bubbles/commands/restart.py
+++ b/bubbles/commands/restart.py
@@ -65,7 +65,7 @@ def restart(payload):
 
 PluginManager.register_plugin(
     restart,
-    r"restart ?(.+)",
+    r"^restart ?(.+)",
     help=f"!restart [{', '.join(SERVICES)}] - restarts the requested bot.",
     interactive_friendly=False,
 )

--- a/bubbles/commands/start.py
+++ b/bubbles/commands/start.py
@@ -61,7 +61,7 @@ def start(payload):
 
 PluginManager.register_plugin(
     start,
-    r"start ?(.+)",
+    r"^start ?(.+)",
     help=f"!start [{', '.join(SERVICES)}] - starts the requested bot.",
     interactive_friendly=False,
 )

--- a/bubbles/commands/stop.py
+++ b/bubbles/commands/stop.py
@@ -50,7 +50,7 @@ def stop(payload):
 
 PluginManager.register_plugin(
     stop,
-    r"stop ?(.+)",
+    r"^stop ?(.+)",
     help=f"!stop [{', '.join(SERVICES)}] - stops the requested bot.",
     interactive_friendly=False,
 )

--- a/bubbles/commands/suggest_upvote_filter_val.py
+++ b/bubbles/commands/suggest_upvote_filter_val.py
@@ -6,7 +6,7 @@ from typing import List
 
 from bubbles.config import PluginManager, reddit
 
-SUGGEST_FILTER_RE = r"suggest filter (r\/|\/r\/)?([a-z_-]+)$"
+SUGGEST_FILTER_RE = r"^suggest filter (r\/|\/r\/)?([a-z_-]+)$"
 
 
 def avg(mylist: List) -> int:

--- a/bubbles/commands/update_and_restart.py
+++ b/bubbles/commands/update_and_restart.py
@@ -20,7 +20,7 @@ def update(payload) -> None:
 
 PluginManager.register_plugin(
     update,
-    r"update$",
+    r"^update$",
     help="!update - pull changes from github and restart!",
     interactive_friendly=False,
 )

--- a/bubbles/commands/vote.py
+++ b/bubbles/commands/vote.py
@@ -20,6 +20,6 @@ def vote(payload):
 
 PluginManager.register_plugin(
     vote,
-    r"vote([ \S]+)?|poll([ \S]+)?",
+    r"^vote([ \S]+)?|poll([ \S]+)?",
     help="!vote [your vote!] Example: `!vote Is this cool or what?`",
 )

--- a/bubbles/message.py
+++ b/bubbles/message.py
@@ -36,11 +36,6 @@ def process_message(payload):
     # search all the loaded plugins to see if any of the regex's match
     plugin = PluginManager.get_plugin(message)
     if plugin:
-        if not plugin["ignore_prefix"]:
-            # Strip the prefix from the message
-            cmd_text = PluginManager.try_get_command_text(message)
-            payload.update({"text": cmd_text})
-
         plugin["callable"](payload)
     elif plugin is False:
         # we're in interactive mode and hit a locked plugin, so we just need

--- a/bubbles/plugins.py
+++ b/bubbles/plugins.py
@@ -1,42 +1,72 @@
 import logging
 import re
-from typing import Callable, Dict, List, Tuple, Union, Any
+from typing import Callable, Dict, List, Tuple, Union, Any, Optional
 
 log = logging.getLogger(__name__)
 
 
+Plugin = Dict[str, Any]
+
+
 class PluginManager:
     # don't import this directly -- import from bubbles.config
-    def __init__(
-        self,
-        command_prefixes: Tuple,
-        interactive_mode: bool,
-    ) -> None:
-        self.plugins: List[Dict[str, Any]] = list()
+    def __init__(self, command_prefixes: Tuple, interactive_mode: bool,) -> None:
+        self.plugins: List[Plugin] = list()
         self.callbacks: List[Callable] = list()
         self.command_prefixes = command_prefixes
         self.interactive_mode = interactive_mode
 
-    def message_is_for_us(self, message: str) -> bool:
-        return any(
-            [
-                message.lower().startswith(prefix.lower())
-                for prefix in self.command_prefixes
-            ]
-        )
+    def try_get_command_text(self, message: str) -> Optional[str]:
+        """Try to get the text content of a command.
 
-    def get_plugin(self, message: str) -> Union[Callable, None, bool]:
-        for plugin in self.plugins:
-            if plugin["ignore_prefix"] or self.message_is_for_us(message):
-                result = re.search(plugin.get("regex", None), message)
-                if result:
-                    if self.interactive_mode and not plugin['interactive_friendly']:
-                        log.warning(
-                            f"Plugin {plugin['callable']} cannot be run in"
-                            f" interactive mode."
-                        )
-                        return False
-                    return plugin["callable"]
+        This checks if the message has one of the command prefixes.
+        If yes, it returns the rest of the message without the prefix.
+        If no, it returns `None`.
+        """
+        for prefix in self.command_prefixes:
+            # Check if the message starts with the prefix
+            if message.lower().startswith(prefix.lower()):
+                # Remove the prefix from the message
+                return message[len(prefix) :].strip()
+
+        return None
+
+    def get_plugin(self, message: str) -> Union[Plugin, None, bool]:
+        """Get the plugin corresponding to the given message."""
+
+        def test_plugin(plg, text: str) -> Union[Plugin, None, bool]:
+            """Test if the plugin can handle the given text."""
+            if re.search(plg.get("regex", None), text):
+                if self.interactive_mode and not plg["interactive_friendly"]:
+                    log.warning(
+                        f"Plugin {plg['callable']} cannot be run in"
+                        f" interactive mode."
+                    )
+                    return False
+                return plugin
+            return None
+
+        prefix_plugins = [
+            plugin for plugin in self.plugins if not plugin["ignore_prefix"]
+        ]
+
+        # If the command has a prefix, look at the prefix plugins first
+        if cmd_text := self.try_get_command_text(message):
+            for plugin in prefix_plugins:
+                result = test_plugin(plugin, cmd_text)
+                if result is not None:
+                    return result
+
+        no_prefix_plugins = [
+            plugin for plugin in self.plugins if plugin["ignore_prefix"]
+        ]
+
+        # Otherwise, look at plugins without the prefix
+        for plugin in no_prefix_plugins:
+            result = test_plugin(plugin, message)
+            if result is not None:
+                return result
+
         # the message we received doesn't match anything our plugins are
         # looking for.
         return None


### PR DESCRIPTION
Relevant issue: Closes #10 (maybe)

## Description:

This improves the command recognition such that 1) prefix commands are tested first if a prefix is detected, 2) the prefix is not included in the regex test for the command and 3) most command regexes now require the keyword to be at the start of the message.

No idea if this actually works, but I guess we can try.

## Checklist:

- [x] Code Quality
- [ ] Pep-8
- [ ] Tests (if applicable)
- [ ] Success Criteria Met
- [x] Inline Documentation
- [ ] Wiki Documentation (if applicable)
