### PR TITLE
Improve formatting of transcription check reminders

### DIFF
--- a/bubbles/commands/periodic/transcription_check_ping.py
+++ b/bubbles/commands/periodic/transcription_check_ping.py
@@ -272,15 +272,15 @@ def _get_check_reminder(aggregate: List) -> str:
         # Add unclaimed checks
         unclaimed = mod_aggregate["unclaimed"]
         if len(unclaimed) > 0:
-            reminder += "- *[UNCLAIMED]*: "
+            reminder += "- [UNCLAIMED]: "
             fragments = [_get_check_fragment(check) for check in unclaimed]
-            reminder += ",".join(fragments) + "\n"
+            reminder += ", ".join(fragments) + "\n"
 
         # Add claimed checks
         for mod, claimed in mod_aggregate["claimed"].items():
-            reminder += f"- *u/{mod}*: "
+            reminder += f"- u/{mod}: "
             fragments = [_get_check_fragment(check) for check in claimed]
-            reminder += ",".join(fragments) + "\n"
+            reminder += ", ".join(fragments) + "\n"
 
     return reminder
 

--- a/bubbles/test/commands/periodic/test_transcription_check_ping.py
+++ b/bubbles/test/commands/periodic/test_transcription_check_ping.py
@@ -426,12 +426,12 @@ def test_get_check_reminder() -> None:
     expected = """*Pending Transcription Checks:*
 
 *12-48 hours*:
-- *u/mod556*: <https://example.com|u/user123>
+- u/mod556: <https://example.com|u/user123>
 *4-7 days*:
-- *[UNCLAIMED]*: <https://example.com|u/user123>
-- *u/mod974*: <https://example.com|u/user123>
+- [UNCLAIMED]: <https://example.com|u/user123>
+- u/mod974: <https://example.com|u/user123>
 *7+ days :rotating_light:*:
-- *u/mod123*: <https://example.com|u/user123>
+- u/mod123: <https://example.com|u/user123>
 """
 
     actual = _get_check_reminder(aggregate)


### PR DESCRIPTION
Relevant issue: N/A

## Description:

This PR makes minor improvements to the transcription check reminders.

- Add spaces between usernames
- Remove bolding from mod usernames (to avoid visual clash with times)

## Checklist:

- [x] Code Quality
- [x] Pep-8
- [x] Tests (if applicable)
- [x] Success Criteria Met
- [ ] Inline Documentation
- [ ] Wiki Documentation (if applicable)
